### PR TITLE
🎨 项目依赖范围更改为 provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j-api.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.theword.queqiao</groupId>
     <artifactId>queqiao-tool</artifactId>
-    <version>0.2.4</version>
+    <version>0.2.5</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -15,11 +15,11 @@
         <!--其他版本号属性-->
         <gson.version>2.10.1</gson.version>
         <lombok.version>1.18.30</lombok.version>
-        <snakeyaml.version>2.2</snakeyaml.version>
-        <slf4j-api.version>1.7.32</slf4j-api.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
+        <slf4j-api.version>1.7.25</slf4j-api.version>
         <commons-io.version>2.15.1</commons-io.version>
-        <slf4j-simple.version>1.7.36</slf4j-simple.version>
-        <java-webSocket.version>1.5.3</java-webSocket.version>
+        <slf4j-simple.version>1.7.25</slf4j-simple.version>
+        <java-webSocket.version>1.4.0</java-webSocket.version>
         <junit-jupiter-api.version>5.10.0</junit-jupiter-api.version>
     </properties>
 
@@ -45,6 +45,39 @@
                         <goals>
                             <goal>javadoc</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <relocations>
+                                <!-- 可选：重命名 SLF4J 包路径，避免与其他 Mod 冲突 -->
+<!--                                <relocation>-->
+<!--                                    <pattern>org.slf4j</pattern>-->
+<!--                                    <shadedPattern>com.github.theword.queqiao.shaded.slf4j</shadedPattern>-->
+<!--                                </relocation>-->
+                            </relocations>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -86,12 +119,14 @@
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>Java-WebSocket</artifactId>
             <version>${java-webSocket.version}</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <commons-io.version>2.15.1</commons-io.version>
         <slf4j-simple.version>1.7.25</slf4j-simple.version>
-        <java-webSocket.version>1.4.0</java-webSocket.version>
+        <java-webSocket.version>1.5.3</java-webSocket.version>
         <junit-jupiter-api.version>5.10.0</junit-jupiter-api.version>
     </properties>
 

--- a/src/main/java/com/github/theword/queqiao/tool/config/CommonConfig.java
+++ b/src/main/java/com/github/theword/queqiao/tool/config/CommonConfig.java
@@ -39,7 +39,7 @@ public abstract class CommonConfig {
         try {
             Yaml yaml = new Yaml();
             Reader reader = Files.newBufferedReader(path);
-            Map<String, Object> configMap = yaml.load(reader);
+            Map<String, Object> configMap = yaml.loadAs(reader, Map.class);
             loadConfigValues(configMap);
             logger.info("读取配置文件 {} 成功。", fileName);
         } catch (IOException exception) {


### PR DESCRIPTION
- 更新 SnakeYAML 版本至 1.33- 更新 SLF4J 版本至 1.7.25
- 更新 Java-WebSocket版本至 1.4.0
- 添加 Maven Shade 插件用于打包和重命名依赖- 将 SnakeYAML 和 Java-WebSocket 依赖范围更改为 provided

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

更新项目依赖和打包配置

Bug 修复：
- 使用 `yaml.loadAs` 进行类型安全的 YAML 解析

增强：
- 更新 SnakeYAML 到 1.33，SLF4J 到 1.7.25，以及 Java-WebSocket 到 1.4.0
- 更改 SnakeYAML 和 Java-WebSocket 依赖范围为 `provided`

构建：
- 提升项目版本到 0.2.5
- 添加 Maven Shade 插件用于打包和依赖重定位

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update project dependencies and packaging configuration

Bug Fixes:
- Use yaml.loadAs for type-safe YAML parsing

Enhancements:
- Update SnakeYAML to 1.33, SLF4J to 1.7.25, and Java-WebSocket to 1.4.0
- Change SnakeYAML and Java-WebSocket dependency scope to provided

Build:
- Bump project version to 0.2.5
- Add Maven Shade plugin for packaging and dependency relocation

</details>