### PR TITLE
Dev

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.theword.queqiao</groupId>
     <artifactId>queqiao-tool</artifactId>
-    <version>0.2.5</version>
+    <version>0.2.6</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/java/com/github/theword/queqiao/tool/config/Config.java
+++ b/src/main/java/com/github/theword/queqiao/tool/config/Config.java
@@ -105,13 +105,7 @@ public class Config extends CommonConfig {
     private void loadWebsocketServerConfig(Map<String, Object> configMap) {
         Map<String, Object> websocketServerConfig = (Map<String, Object>) configMap.get("websocket_server");
         websocketServer.setEnable((Boolean) websocketServerConfig.get("enable"));
-        String host = (String) websocketServerConfig.get("host");
-        if (host.equals("0.0.0.0") || host.equals("127.0.0.1") || host.equals("localhost"))
-            websocketServer.setHost((String) websocketServerConfig.get("host"));
-        else {
-            websocketServer.setHost("127.0.0.1");
-            logger.warn("哪有你这么设置IP的？你确定你改的host是对的？？我已经帮你改到 127.0.0.1 了，好好想想再去改host！！！");
-        }
+        websocketServer.setHost((String) websocketServerConfig.get("host"));
         websocketServer.setPort((int) websocketServerConfig.get("port"));
     }
 


### PR DESCRIPTION
## Sourcery 总结

移除 WebSocket 服务器的限制性主机验证并更新项目版本。

增强功能：
- 允许在 WebSocket 服务器上设置任何已配置的主机，方法是移除回退逻辑和警告消息。

构建：
- 将项目版本从 0.2.5 提升到 0.2.6。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove restrictive host validation for the WebSocket server and update the project version.

Enhancements:
- Allow any configured host to be set on the WebSocket server by removing fallback logic and warning message.

Build:
- Bump project version from 0.2.5 to 0.2.6.

</details>