### PR TITLE
build:升级 SnakeYAML 依赖至 2.0版本并更新配置加载方法- 将 SnakeYAML 依赖从 1.33 版本升级到 2.0版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.theword.queqiao</groupId>
     <artifactId>queqiao-tool</artifactId>
-    <version>0.2.7</version>
+    <version>0.2.8</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -15,7 +15,7 @@
         <!--其他版本号属性-->
         <gson.version>2.10.1</gson.version>
         <lombok.version>1.18.30</lombok.version>
-        <snakeyaml.version>1.33</snakeyaml.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <slf4j-api.version>1.7.25</slf4j-api.version>
         <commons-io.version>2.15.1</commons-io.version>
         <slf4j-simple.version>1.7.25</slf4j-simple.version>

--- a/src/main/java/com/github/theword/queqiao/tool/config/CommonConfig.java
+++ b/src/main/java/com/github/theword/queqiao/tool/config/CommonConfig.java
@@ -39,7 +39,7 @@ public abstract class CommonConfig {
         try {
             Yaml yaml = new Yaml();
             Reader reader = Files.newBufferedReader(path);
-            Map<String, Object> configMap = yaml.loadAs(reader, Map.class);
+            Map<String, Object> configMap = yaml.load(reader);
             loadConfigValues(configMap);
             logger.info("读取配置文件 {} 成功。", fileName);
         } catch (IOException exception) {


### PR DESCRIPTION
- 修改配置加载方法，使用 yaml.load 替代 yaml.loadAs
- 更新项目版本号至 0.2.8

## Sourcery 总结

将 SnakeYAML 依赖升级到 2.0 版本，并将项目版本提升到 0.2.8，并更新配置加载以使用 yaml.load。

增强功能：
- 在配置加载器中将 `yaml.loadAs` 替换为 `yaml.load`

构建：
- 将 SnakeYAML 依赖提升到 2.0
- 更新项目版本到 0.2.8

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade SnakeYAML dependency to version 2.0, bump project version to 0.2.8, and update configuration loading to use yaml.load.

Enhancements:
- Replace yaml.loadAs with yaml.load in configuration loader

Build:
- Bump SnakeYAML dependency to 2.0
- Update project version to 0.2.8

</details>