### PR TITLE
:art: Add GH_TOKEN environment variable for GitHub release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,5 @@ jobs:
 
       - name: Upload to Release
         run: gh release upload v${{ env.VERSION }} build/libs/queqiao-tool-${{ env.VERSION }}.jar --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Sourcery 总结

增强：
- 在发布工作流中添加 GH_TOKEN 环境变量，用于验证 GitHub CLI 以上传发布资产

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Add GH_TOKEN environment variable in the release workflow to authenticate GitHub CLI for uploading release assets

</details>