### PR TITLE
:art: Update GitHub Actions workflows to use environment variables fo…

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [ "main", "dev" ]
 
-permissions:
-  contents: write  # 允许推送代码到分支
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: write
       packages: write
+    env:
+      GH_ACTOR: ${{ github.actor }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - uses: actions/checkout@v5
@@ -50,11 +53,6 @@ jobs:
 
       - name: Build and Publish with Gradle
         run: ./gradlew publish
-        env:
-          GITHUB_ACTOR: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload to Release
         run: gh release upload v${{ env.VERSION }} build/libs/queqiao-tool-${{ env.VERSION }}.jar --clobber
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,8 +71,8 @@ publishing {
             name = "GitHubPackages"
             url = uri("https://maven.pkg.github.com/17TheWord/QueQiaoTool")
             credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
+                username = System.getenv("GH_ACTOR")
+                password = System.getenv("GH_TOKEN")
             }
         }
     }


### PR DESCRIPTION
…r authentication

## Sourcery 摘要

通过切换到 `GH_ACTOR` 和 `GH_TOKEN` 环境变量、整合 GitHub Actions 作业中的环境变量声明以及添加所需的权限，统一跨工作流和构建的认证。

构建：
- 更新 Gradle 发布凭据，使其从环境中读取 `GH_ACTOR` 和 `GH_TOKEN`

CI：
- 在发布工作流中，在作业级别整合 `GH_ACTOR` 和 `GH_TOKEN` 环境变量
- 为 javadoc 构建作业添加 `contents: write` 权限

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize authentication across workflows and build by switching to GH_ACTOR and GH_TOKEN environment variables, consolidating env declarations in GitHub Actions jobs, and adding required permissions.

Build:
- Update Gradle publishing credentials to read GH_ACTOR and GH_TOKEN from environment

CI:
- Consolidate GH_ACTOR and GH_TOKEN env variables at the job level in the release workflow
- Add contents: write permission to the javadoc build job

</details>