### PR TITLE
dev

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,7 @@ tasks.withType<Javadoc> {
         this as StandardJavadocDocletOptions
         encoding = "UTF-8"
         charSet = "UTF-8"
+        docEncoding = "UTF-8"
         links("https://docs.oracle.com/javase/8/docs/api/")
         if (JavaVersion.current().isJava9Compatible) {
             addBooleanOption("html5", true)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m
 org.gradle.parallel=true
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 # Project versions
 projectGroup=com.github.theword.queqiao
 projectVersion=0.3.1


### PR DESCRIPTION
## 由 Sourcery 提供摘要

启用 Gradle 配置缓存并确保 Javadoc 输出使用 UTF-8 编码

Build:
- 通过 `org.gradle.configuration-cache` 属性启用 Gradle 配置缓存
- 在 Javadoc 任务配置中添加将 `docEncoding` 设置为 UTF-8

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Gradle configuration cache and ensure Javadoc output uses UTF-8 encoding

Build:
- Enable Gradle configuration cache via org.gradle.configuration-cache property
- Add docEncoding set to UTF-8 in Javadoc task configuration

</details>