### PR TITLE
:sparkles: 新增命令payload

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,10 +36,10 @@ dependencies {
     implementation("org.java-websocket:Java-WebSocket:${property("javaWebSocketVersion")}")
     implementation("org.slf4j:slf4j-api:${property("slf4jApiVersion")}")
     implementation("org.glavo:rcon-java:${property("glavoRconVersion")}")
-    
+
     testImplementation("org.slf4j:slf4j-simple:${property("slf4jSimpleVersion")}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${property("junitJupiterApiVersion")}")
-    
+
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${property("junitJupiterApiVersion")}")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:${property("junitJupiterPlatformLauncherVersion")}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 # Project versions
 projectGroup=com.github.theword.queqiao
-projectVersion=0.3.4
+projectVersion=0.3.5
 # Lib versions
 gsonVersion=2.10.1
 glavoRconVersion=3.0

--- a/src/main/java/com/github/theword/queqiao/tool/GlobalContext.java
+++ b/src/main/java/com/github/theword/queqiao/tool/GlobalContext.java
@@ -107,12 +107,12 @@ public class GlobalContext {
         if (!config.getRcon().isEnable()) {
             logger.warn("Rcon 未启用，无法发送命令");
             return "Rcon 未启用，无法发送命令";
-        } else if (!rconClient.isConnected()) {
-            logger.warn("Rcon 未连接，无法发送命令");
-            return "Rcon 未连接，无法发送命令";
         } else if (rconClient == null) {
             logger.warn("Rcon 客户端未初始化，无法发送命令");
             return "Rcon 客户端未初始化，无法发送命令";
+        } else if (!rconClient.isConnected()) {
+            logger.warn("Rcon 未连接，无法发送命令");
+            return "Rcon 未连接，无法发送命令";
         } else {
             logger.info("发送 Rcon 命令: {}", command);
             return rconClient.sendCommand(command);

--- a/src/main/java/com/github/theword/queqiao/tool/config/Config.java
+++ b/src/main/java/com/github/theword/queqiao/tool/config/Config.java
@@ -210,10 +210,11 @@ public class Config extends CommonConfig {
      *
      * @param configMap Rcon
      */
-    @SuppressWarnings("unchecked")
     private void loadRconConfig(Map<String, Object> configMap) {
-        Map<String, Object> rconConfig = (Map<String, Object>) configMap.get("rcon");
-        if (rconConfig == null) return;
+        Object rconObj = configMap.get("rcon");
+        if (!(rconObj instanceof Map)) return;
+        @SuppressWarnings("unchecked")
+        Map<String, Object> rconConfig = (Map<String, Object>) rconObj;
         rcon.setEnable((Boolean) rconConfig.getOrDefault("enable", false));
         rcon.setPort((Integer) rconConfig.getOrDefault("port", 25575));
         rcon.setPassword((String) rconConfig.getOrDefault("password", ""));

--- a/src/main/java/com/github/theword/queqiao/tool/config/Config.java
+++ b/src/main/java/com/github/theword/queqiao/tool/config/Config.java
@@ -213,8 +213,7 @@ public class Config extends CommonConfig {
     private void loadRconConfig(Map<String, Object> configMap) {
         Object rconObj = configMap.get("rcon");
         if (!(rconObj instanceof Map)) return;
-        @SuppressWarnings("unchecked")
-        Map<String, Object> rconConfig = (Map<String, Object>) rconObj;
+        @SuppressWarnings("unchecked") Map<String, Object> rconConfig = (Map<String, Object>) rconObj;
         rcon.setEnable((Boolean) rconConfig.getOrDefault("enable", false));
         rcon.setPort((Integer) rconConfig.getOrDefault("port", 25575));
         rcon.setPassword((String) rconConfig.getOrDefault("password", ""));

--- a/src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java
@@ -117,9 +117,10 @@ public class HandleProtocolMessage {
             case "send_command":
                 return Response.failed(500, api + " is not supported now", null, echo);
             case "send_rcon_command":
+                CommandPayload commandPayload = gson.fromJson(data, CommandPayload.class);
                 String result;
                 try {
-                    result = GlobalContext.sendRconCommand(data.getAsString());
+                    result = GlobalContext.sendRconCommand(commandPayload.getCommand());
                     return Response.success(result, echo);
                 } catch (IllegalArgumentException e) {
                     logger.warn("Rcon 执行命令时出现问题，命令发送失败：{}", e.getMessage());

--- a/src/main/java/com/github/theword/queqiao/tool/payload/CommandPayload.java
+++ b/src/main/java/com/github/theword/queqiao/tool/payload/CommandPayload.java
@@ -1,0 +1,22 @@
+package com.github.theword.queqiao.tool.payload;
+
+
+/**
+ * 命令负载类（CommandPayload）
+ *
+ * <p>表示一条命令的负载。
+ */
+public class CommandPayload {
+
+    private String command;
+
+
+    public String getCommand() {
+        return command;
+    }
+
+    public void setCommand(String command) {
+        this.command = command;
+    }
+
+}


### PR DESCRIPTION
## Sourcery 总结

实现 RCON 支持，包含配置、客户端、命令载荷和协议集成；重构命令返回处理以使用 HandleCommandReturnMessageService；更新构建脚本、版本和配置。

新功能：
- 引入 RconConfig 和 RconClient 来管理 RCON 连接
- 在 HandleProtocolMessage 中添加 `send_rcon_command` API，使用 `CommandPayload` 载荷
- 扩展 GlobalContext，以在 WebsocketManager 旁边初始化、重新加载、重启和关闭 Rcon

改进：
- 将 `Tool.commandReturn` 调用替换为 `HandleCommandReturnMessageService.sendReturnMessage`
- 将 HandleCommandReturnMessageService 从接口转换为抽象类，并废弃旧的 `Tool.commandReturn`

构建：
- 添加 `glavo:rcon-java` 依赖，并将 `projectVersion` 提升至 0.3.5
- 移除 Checkstyle 插件，禁用 Javadoc doclint，并更新 GitHub 发布工作流以上传通配符 jar 包

文档：
- 在 `config.yml` 中添加 Rcon 客户端配置部分

杂项：
- 废弃 `Tool.commandReturn` 方法

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Implement RCON support with configuration, client, command payloads, and protocol integration; refactor command return handling to use HandleCommandReturnMessageService; update build scripts, version, and config.

New Features:
- Introduce RconConfig and RconClient to manage RCON connections
- Add send_rcon_command API in HandleProtocolMessage with CommandPayload payload
- Extend GlobalContext to initialize, reload, restart, and shutdown Rcon alongside WebsocketManager

Enhancements:
- Replace Tool.commandReturn calls with HandleCommandReturnMessageService.sendReturnMessage
- Convert HandleCommandReturnMessageService from interface to abstract class and deprecate legacy Tool.commandReturn

Build:
- Add glavo:rcon-java dependency and bump projectVersion to 0.3.5
- Remove Checkstyle plugin, disable Javadoc doclint, and update GitHub release workflow to upload wildcard jar

Documentation:
- Add Rcon client configuration section in config.yml

Chores:
- Deprecate Tool.commandReturn method

</details>