### PR TITLE
🔧 升级 GitHub Actions 依赖至最新版本

### DIFF
--- a/.github/actions/set-java/action.yml
+++ b/.github/actions/set-java/action.yml
@@ -11,20 +11,20 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         java-version: ${{ inputs.java-version }}
         distribution: temurin
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@017a9effdb900e5b5b2fddfb590a105619dca3c3 # v4.4.2
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Make Gradle Wrapper Executable
       shell: bash
       run: chmod +x ./gradlew
 
     - name: Cache Gradle packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Java & Gradle
         uses: ./.github/actions/set-java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup Java & Gradle
         uses: ./.github/actions/set-java

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Java & Gradle
         uses: ./.github/actions/set-java
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew compileJava
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/reports/jacoco/test/jacocoTestReport.xml

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions
 plugins {
     java
     `maven-publish`
-    id("com.diffplug.spotless") version "8.0.0"
     jacoco
 }
 
@@ -64,15 +63,7 @@ tasks.withType<Javadoc> {
     classpath += sourceSets.main.get().output + sourceSets.main.get().compileClasspath
 }
 
-spotless {
-    java {
-        eclipse().configFile("formatter-custom.xml")
-        target("src/main/java/**/*.java", "src/test/java/**/*.java")
-    }
-}
-
 tasks.named("check") {
-    dependsOn("spotlessCheck")
     dependsOn("jacocoTestReport")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 # Project versions
 projectGroup=com.github.theword.queqiao
-projectVersion=0.6.7
+projectVersion=0.6.8
 # Lib versions
 gsonVersion=2.8.0
 glavoRconVersion=3.0


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

更新 GitHub Actions 工作流和复合操作，以使用最新版本的核心 Actions 和 Gradle 设置。

构建（Build）：
- 将 `actions/setup-java` 升级到 `v5`，并在共享复合操作中将 Gradle 设置的 Action 切换到其最新的 `v6` 标签。

持续集成（CI）：
- 在测试、javadoc 和发布工作流中，将 `actions/checkout` 升级到 `v6`，并将 `codecov/codecov-action` 升级到 `v6`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update GitHub Actions workflows and composite action to use the latest versions of core actions and Gradle setup.

Build:
- Bump actions/setup-java to v5 and switch Gradle setup action to its latest v6 tag in the shared composite action.

CI:
- Upgrade actions/checkout to v6 and codecov/codecov-action to v6 across test, javadoc, and release workflows.

</details>