### PR TITLE
Dev

### DIFF
--- a/.github/prompts/project-summary.prompt.md
+++ b/.github/prompts/project-summary.prompt.md
@@ -1,0 +1,174 @@
+---
+description: "总结 QueQiaoTool 项目现状、架构、协议能力与维护关注点"
+name: "QueQiaoTool Project Summary"
+agent: "agent"
+---
+# QueQiaoTool 项目总结
+
+## 项目定位
+
+QueQiaoTool 是 QueQiao 生态中的通用 Java 工具库，面向 Minecraft 服务端插件/模组平台适配层提供统一能力。它抽象并集中实现：
+
+- WebSocket Server / Client 正反向连接。
+- JSON 请求、响应与事件推送协议。
+- 配置读取与默认配置管理。
+- 玩家事件模型与消息 payload。
+- 广播、私聊、Title、ActionBar、Rcon、服务器状态等 API 的协议分发。
+- 命令框架、重载、客户端重连、服务端信息查询。
+- 多语言/翻译辅助与服务器状态采集。
+
+QueQiaoTool 本身不直接依赖某个 Minecraft 服务端 API，而是通过接口由 QueQiao 各平台实现具体游戏内行为。
+
+## 技术栈
+
+- 语言：Java
+- 目标版本：Java 8
+- 构建：Gradle Kotlin DSL
+- 测试：JUnit 5
+- 覆盖率：JaCoCo
+- 发布：Maven Publish 到 GitHub Packages
+- 主要依赖：
+  - `com.google.code.gson:gson`
+  - `org.java-websocket:Java-WebSocket`
+  - `org.yaml:snakeyaml`
+  - `org.slf4j:slf4j-api`
+  - `org.glavo:rcon-java`
+  - `commons-io:commons-io`
+
+## 核心包结构
+
+根包：`src/main/java/com/github/theword/queqiao/tool/`
+
+- `GlobalContext.java`：全局上下文与生命周期入口，负责加载配置、初始化 WebSocket、Rcon、翻译、状态采集，并暴露事件发送与重载逻辑。
+- `config/`：配置模型，包括 `Config`、`CommonConfig`、`WebSocketServerConfig`、`WebSocketClientConfig`、`RconConfig`、`SubscribeEventConfig`。
+- `websocket/`：`WsServer` 与 `WsClient`，实现服务端监听与客户端反向连接。
+- `utils/`：`WebsocketManager`、`Tool`、`GsonUtils`、`ServerStatusCollector`、`SystemMetricsCollector`、`MinecraftPingClient` 等辅助能力。
+- `handle/`：协议处理与平台能力接口。
+  - `HandleProtocolMessage`：解析 `api`、`data`、`echo` 并分派到具体 API。
+  - `HandleApiService`：由平台实现的游戏内消息发送能力。
+  - `HandleCommandReturnMessageService`：由平台实现的命令反馈与权限能力。
+- `payload/`：请求载荷模型，如 `BasePayload`、`MessagePayload`、`PrivateMessagePayload`、`TitlePayload`、`CommandPayload`。
+- `response/`：响应模型，如 `Response`、`PrivateMessageResponse`、`ResponseEnum`。
+- `event/`：玩家事件模型。
+  - 顶层事件：`PlayerChatEvent`、`PlayerCommandEvent`、`PlayerDeathEvent`、`PlayerJoinEvent`、`PlayerQuitEvent`、`PlayerAchievementEvent`。
+  - `base/`、`player/`、`model/`：公共事件基类、玩家模型、死亡/成就等嵌套模型。
+- `command/`：命令框架。
+  - `RootCommand`、`SubCommand`、`CommandExecutorHelper`
+  - `subCommand/client/`：重连、全部重连、列表等命令。
+  - `subCommand/server/`：服务器信息命令。
+- `rcon/`：`RconClient`，封装原生 Rcon 调用。
+- `localize/`：`LanguageService`，支持本地翻译文件。
+- `constant/`：基础常量、命令常量、服务端类型、WebSocket 常量消息。
+
+## 生命周期
+
+典型接入流程：
+
+1. 平台层在服务端启动完成后调用 `GlobalContext.init(...)`。
+2. `GlobalContext` 加载 YAML 配置、初始化 Gson、日志、平台接口、WebSocket 管理器、Rcon 客户端、翻译服务和状态采集。
+3. 平台层监听 Minecraft 事件，构造 `BaseEvent` 子类后调用 `GlobalContext.sendEvent(...)`。
+4. 外部应用通过 WebSocket 发送 JSON 请求，由 `HandleProtocolMessage` 分派至平台层 `HandleApiService`。
+5. 服务端关闭前调用 `GlobalContext.shutdown()`，关闭 WebSocket、Rcon 与翻译服务。
+
+## 协议能力
+
+请求基本结构：
+
+- `api`：接口名。
+- `data`：接口参数。
+- `echo`：可选回显字段。
+
+主要 API：
+
+- `broadcast` / `send_msg`：广播消息。
+- `send_private_msg`：发送私聊消息。
+- `send_title`：发送 Title / Subtitle。
+- `send_actionbar`：发送 ActionBar。
+- `send_rcon_command`：执行 Rcon 命令。
+- `get_status`：返回服务器状态快照。
+- `send_command`：当前代码中标记为暂不支持。
+
+主要事件：
+
+- 玩家聊天
+- 玩家命令
+- 玩家死亡
+- 玩家加入
+- 玩家退出
+- 玩家成就/进度
+
+## 配置文件
+
+默认配置文件：`src/main/resources/queqiao/config.yml`
+
+关键配置项：
+
+- `enable`：是否启用。
+- `debug`：是否输出调试日志。
+- `server_name`：服务器名称。
+- `access_token`：连接鉴权 token。
+- `message_prefix`：游戏内消息前缀，支持文本或 Minecraft JSON 组件。
+- `enable_translation`：是否启用翻译。
+- `websocket_server`：WebSocket Server 地址与端口。
+- `websocket_client`：反向连接 URL 列表、重连间隔、最大重连次数。
+- `rcon`：Rcon 开关、端口、密码。
+- `subscribe_event`：玩家事件订阅开关。
+- `ignored_commands`：忽略的命令前缀列表。
+
+## 测试与质量保障
+
+测试目录：`src/test/java/com/github/theword/queqiao/tool/`
+
+已有测试覆盖方向：
+
+- 配置模型：`ConfigTest`、`WebSocketServerConfigTest`、`WebSocketClientConfigTest`、`RconConfigTest`、`SubscribeEventConfigTest`
+- WebSocket：`WsServerTest`、`WsClientTest`
+- 工具：`ToolTest`、`GsonUtilsTest`
+- 响应模型：`ResponseTest`、`ResponseEnumTest`、`PrivateMessageResponseTest`
+- Payload：`BasePayloadTest`、`MessagePayloadTest`、`PrivateMessagePayloadTest`、`TitlePayloadTest`、`CommandPayloadTest`
+- 事件模型：玩家聊天、命令、死亡、加入、退出、成就事件测试
+- 全局上下文：`GlobalContextTest`
+
+构建任务：
+
+- `./gradlew.bat test`
+- `./gradlew.bat build`
+- `./gradlew.bat jacocoTestReport`
+
+发布配置位于 `build.gradle.kts`，会生成主 Jar、Sources Jar、Javadoc Jar，并发布到 GitHub Packages。
+
+## 关键文件
+
+- `README.md`：项目说明、接入方式、协议文档入口、依赖方式。
+- `build.gradle.kts`：构建、测试、JaCoCo、发布配置。
+- `gradle.properties`：项目版本与依赖版本。
+- `settings.gradle.kts`：项目名 `queqiao-tool`。
+- `src/main/resources/queqiao/config.yml`：默认配置模板。
+- `src/main/java/com/github/theword/queqiao/tool/GlobalContext.java`：生命周期核心。
+- `src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java`：协议分发核心。
+- `src/main/java/com/github/theword/queqiao/tool/utils/WebsocketManager.java`：WebSocket 管理核心。
+- `src/main/java/com/github/theword/queqiao/tool/rcon/RconClient.java`：Rcon 封装。
+
+## 优势
+
+- 把跨平台公共逻辑从 QueQiao 各 loader 中抽离，降低平台适配重复成本。
+- 接口边界清晰：平台只需实现消息发送、命令反馈、权限等与服务端 API 相关的部分。
+- 协议模型、事件模型、payload、response 结构较完整。
+- 有测试、JaCoCo、Javadoc、Sources Jar 和 GitHub Packages 发布流程。
+- 保持 Java 8 兼容，适合支持旧版 Minecraft。
+
+## 风险与维护关注点
+
+- `GlobalContext` 静态全局状态较多，测试隔离、重载与并发场景需要谨慎。
+- 协议分发集中在 `HandleProtocolMessage` 的 `switch` 中，API 增多后可维护性会下降。
+- Java 8 兼容限制了部分现代库和语言特性的使用。
+- WebSocket、Rcon、翻译、状态采集均属于运行时敏感能力，应持续关注异常处理与资源关闭。
+- 需要确保 README 中示例版本、`gradle.properties` 的 `projectVersion` 与 QueQiao 的 `tool_version.txt` 保持一致。
+
+## 后续维护建议
+
+- 为每个 API 增加协议级单元测试，尤其是错误请求、缺字段、鉴权失败和 Rcon 异常。
+- 将 `HandleProtocolMessage` 的 API 分发逐步拆成可注册的处理器，降低单类复杂度。
+- 为 `GlobalContext` 增加测试辅助重置方法或实例化上下文，提升测试隔离。
+- 明确 WebSocket 鉴权、心跳、重连、广播失败的行为规范。
+- 为外部接入者补充完整 JSON 示例与响应示例。

--- a/src/main/java/com/github/theword/queqiao/tool/GlobalContext.java
+++ b/src/main/java/com/github/theword/queqiao/tool/GlobalContext.java
@@ -5,6 +5,7 @@ import com.github.theword.queqiao.tool.constant.BaseConstant;
 import com.github.theword.queqiao.tool.constant.CommandConstant;
 import com.github.theword.queqiao.tool.constant.WebsocketConstantMessage;
 import com.github.theword.queqiao.tool.event.base.BaseEvent;
+import com.github.theword.queqiao.tool.exception.rcon.RconCommandException;
 import com.github.theword.queqiao.tool.handle.HandleApiService;
 import com.github.theword.queqiao.tool.handle.HandleCommandReturnMessageService;
 import com.github.theword.queqiao.tool.localize.LanguageService;
@@ -15,8 +16,6 @@ import com.github.theword.queqiao.tool.utils.WebsocketManager;
 import com.google.gson.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 public class GlobalContext {
     private static Config config;
@@ -147,12 +146,12 @@ public class GlobalContext {
      * @param command 命令
      * @return 命令返回结果
      */
-    public static String sendRconCommand(String command) throws IOException {
+    public static String sendRconCommand(String command) throws RconCommandException {
         if (!config.getRcon().isEnable()) {
-            throw new IOException("Rcon 功能未在配置文件中启用");
+            throw RconCommandException.disabled();
         }
         if (rconClient == null || !rconClient.isConnected()) {
-            throw new IOException("Rcon 客户端未连接或已关闭");
+            throw RconCommandException.notConnected();
         }
         return rconClient.sendCommand(command);
     }

--- a/src/main/java/com/github/theword/queqiao/tool/constant/ApiConstants.java
+++ b/src/main/java/com/github/theword/queqiao/tool/constant/ApiConstants.java
@@ -1,0 +1,51 @@
+package com.github.theword.queqiao.tool.constant;
+
+/**
+ * 协议 API 相关常量集合。
+ */
+public final class ApiConstants {
+    private ApiConstants() {
+    }
+
+    /**
+     * 协议 API 名称。
+     */
+    public static final class Api {
+        public static final String BROADCAST = "broadcast";
+        public static final String SEND_MSG = "send_msg";
+        public static final String SEND_TITLE = "send_title";
+        public static final String SEND_ACTIONBAR = "send_actionbar";
+        public static final String SEND_PRIVATE_MSG = "send_private_msg";
+        public static final String SEND_COMMAND = "send_command";
+        public static final String SEND_RCON_COMMAND = "send_rcon_command";
+        public static final String GET_STATUS = "get_status";
+
+        private Api() {
+        }
+    }
+
+    /**
+     * 协议响应码。
+     */
+    public static final class Code {
+        public static final int BAD_REQUEST = 400;
+        public static final int NOT_FOUND = 404;
+        public static final int INTERNAL_ERROR = 500;
+
+        private Code() {
+        }
+    }
+
+    /**
+     * 协议响应消息。
+     */
+    public static final class Message {
+        public static final String UNKNOWN_API = "未知的API：";
+        public static final String PARSE_MESSAGE_FAILED = "解析消息失败";
+        public static final String SEND_COMMAND_UNSUPPORTED = "%s is not supported now";
+        public static final String TITLE_AND_SUBTITLE_EMPTY = "Title and Subtitle cannot both be null";
+
+        private Message() {
+        }
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/constant/BaseConstant.java
+++ b/src/main/java/com/github/theword/queqiao/tool/constant/BaseConstant.java
@@ -11,7 +11,6 @@ public class BaseConstant {
     public static final String COMMAND_HEADER = MOD_ID;
     public static final String LAUNCHING = "正在启动";
     public static final String INITIALIZED = "初始化完成";
-    public static final String UNKNOWN_API = "未知的API：";
 
     public static final String UNKNOWN = "unknown";
 }

--- a/src/main/java/com/github/theword/queqiao/tool/exception/QueQiaoToolException.java
+++ b/src/main/java/com/github/theword/queqiao/tool/exception/QueQiaoToolException.java
@@ -1,0 +1,14 @@
+package com.github.theword.queqiao.tool.exception;
+
+/**
+ * QueQiaoTool 基础异常。
+ */
+public class QueQiaoToolException extends RuntimeException {
+    public QueQiaoToolException(String message) {
+        super(message);
+    }
+
+    public QueQiaoToolException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/exception/protocol/ProtocolHandlerRegistryException.java
+++ b/src/main/java/com/github/theword/queqiao/tool/exception/protocol/ProtocolHandlerRegistryException.java
@@ -1,0 +1,41 @@
+package com.github.theword.queqiao.tool.exception.protocol;
+
+import com.github.theword.queqiao.tool.exception.QueQiaoToolException;
+
+/**
+ * 协议 API 处理器注册异常。
+ */
+public class ProtocolHandlerRegistryException extends QueQiaoToolException {
+    private final Reason reason;
+
+    private ProtocolHandlerRegistryException(Reason reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+    private static ProtocolHandlerRegistryException of(Reason reason, String message) {
+        return new ProtocolHandlerRegistryException(reason, message);
+    }
+
+    public static ProtocolHandlerRegistryException apiBlank() {
+        return of(Reason.API_BLANK, "Protocol handler api must not be null or empty");
+    }
+
+    public static ProtocolHandlerRegistryException handlerNull(String api) {
+        return of(Reason.HANDLER_NULL, "Protocol handler for api '" + api + "' must not be null");
+    }
+
+    public static ProtocolHandlerRegistryException duplicated(String api) {
+        return of(Reason.DUPLICATED, "Protocol handler for api '" + api + "' is already registered");
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public enum Reason {
+        API_BLANK,
+        HANDLER_NULL,
+        DUPLICATED
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/exception/protocol/ResponseStatusException.java
+++ b/src/main/java/com/github/theword/queqiao/tool/exception/protocol/ResponseStatusException.java
@@ -1,0 +1,20 @@
+package com.github.theword.queqiao.tool.exception.protocol;
+
+import com.github.theword.queqiao.tool.exception.QueQiaoToolException;
+
+/**
+ * 响应状态解析异常。
+ */
+public class ResponseStatusException extends QueQiaoToolException {
+    private ResponseStatusException(String message) {
+        super(message);
+    }
+
+    private static ResponseStatusException of(String message) {
+        return new ResponseStatusException(message);
+    }
+
+    public static ResponseStatusException unknown(String value) {
+        return of("Unknown response status: " + value);
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/exception/rcon/RconCommandException.java
+++ b/src/main/java/com/github/theword/queqiao/tool/exception/rcon/RconCommandException.java
@@ -1,0 +1,51 @@
+package com.github.theword.queqiao.tool.exception.rcon;
+
+import com.github.theword.queqiao.tool.exception.QueQiaoToolException;
+
+/**
+ * Rcon 命令执行异常。
+ */
+public class RconCommandException extends QueQiaoToolException {
+    private final Reason reason;
+
+    private RconCommandException(Reason reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+    private RconCommandException(Reason reason, String message, Throwable cause) {
+        super(message, cause);
+        this.reason = reason;
+    }
+
+    private static RconCommandException of(Reason reason, String message) {
+        return new RconCommandException(reason, message);
+    }
+
+    private static RconCommandException of(Reason reason, String message, Throwable cause) {
+        return new RconCommandException(reason, message, cause);
+    }
+
+    public static RconCommandException disabled() {
+        return of(Reason.DISABLED, "Rcon 功能未在配置文件中启用");
+    }
+
+    public static RconCommandException notConnected() {
+        return of(Reason.NOT_CONNECTED, "Rcon 客户端未连接或已关闭");
+    }
+
+    public static RconCommandException failed(Throwable cause) {
+        String message = cause.getMessage() != null ? cause.getMessage() : "Rcon 命令执行失败";
+        return of(Reason.FAILED, message, cause);
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public enum Reason {
+        DISABLED,
+        NOT_CONNECTED,
+        FAILED
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/exception/status/MinecraftPingException.java
+++ b/src/main/java/com/github/theword/queqiao/tool/exception/status/MinecraftPingException.java
@@ -1,0 +1,68 @@
+package com.github.theword.queqiao.tool.exception.status;
+
+import com.github.theword.queqiao.tool.exception.QueQiaoToolException;
+
+public class MinecraftPingException extends QueQiaoToolException {
+
+    private final Reason reason;
+
+    private MinecraftPingException(Reason reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+    private MinecraftPingException(Reason reason, String message, Throwable cause) {
+        super(message, cause);
+        this.reason = reason;
+    }
+
+    private static MinecraftPingException of(Reason reason, String message) {
+        return new MinecraftPingException(reason, message);
+    }
+
+    private static MinecraftPingException of(Reason reason, String message, Throwable cause) {
+        return new MinecraftPingException(reason, message, cause);
+    }
+
+    public static MinecraftPingException invalidPacketLength(int length) {
+        return of(Reason.INVALID_PACKET_LENGTH, "状态响应包长度非法: " + length);
+    }
+
+    public static MinecraftPingException invalidPacketId(int packetId) {
+        return of(Reason.INVALID_PACKET_ID, "状态响应包 ID 非法: " + packetId);
+    }
+
+    public static MinecraftPingException invalidJsonLength(int length) {
+        return of(Reason.INVALID_JSON_LENGTH, "状态响应 JSON 长度非法: " + length);
+    }
+
+    public static MinecraftPingException jsonParseFailed() {
+        return of(Reason.JSON_PARSE_FAILED, "状态响应 JSON 解析失败");
+    }
+
+    public static MinecraftPingException connectionClosed(String message) {
+        return of(Reason.CONNECTION_CLOSED, message);
+    }
+
+    public static MinecraftPingException varIntTooLong() {
+        return of(Reason.VAR_INT_TOO_LONG, "VarInt 过长");
+    }
+
+    public static MinecraftPingException ioFailed(Throwable cause) {
+        return of(Reason.IO_FAILED, "Minecraft Server List Ping IO 失败", cause);
+    }
+
+    public Reason getReason() {
+        return reason;
+    }
+
+    public enum Reason {
+        INVALID_PACKET_LENGTH,
+        INVALID_PACKET_ID,
+        INVALID_JSON_LENGTH,
+        JSON_PARSE_FAILED,
+        CONNECTION_CLOSED,
+        VAR_INT_TOO_LONG,
+        IO_FAILED
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java
@@ -4,12 +4,18 @@ import static com.github.theword.queqiao.tool.utils.Tool.debugLog;
 
 import com.github.theword.queqiao.tool.GlobalContext;
 import com.github.theword.queqiao.tool.constant.BaseConstant;
-import com.github.theword.queqiao.tool.payload.*;
-import com.github.theword.queqiao.tool.response.PrivateMessageResponse;
+import com.github.theword.queqiao.tool.handle.protocol.BroadcastHandler;
+import com.github.theword.queqiao.tool.handle.protocol.GetStatusHandler;
+import com.github.theword.queqiao.tool.handle.protocol.ProtocolHandler;
+import com.github.theword.queqiao.tool.handle.protocol.ProtocolHandlerRegistry;
+import com.github.theword.queqiao.tool.handle.protocol.SendActionBarHandler;
+import com.github.theword.queqiao.tool.handle.protocol.SendCommandHandler;
+import com.github.theword.queqiao.tool.handle.protocol.SendPrivateMessageHandler;
+import com.github.theword.queqiao.tool.handle.protocol.SendRconCommandHandler;
+import com.github.theword.queqiao.tool.handle.protocol.SendTitleHandler;
+import com.github.theword.queqiao.tool.payload.BasePayload;
 import com.github.theword.queqiao.tool.response.Response;
-import com.github.theword.queqiao.tool.utils.ServerStatusCollector;
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import org.java_websocket.WebSocket;
 import org.slf4j.Logger;
 
@@ -21,12 +27,31 @@ import java.util.HashMap;
 public class HandleProtocolMessage {
 
     private final Gson gson;
-    private static final HandleApiService handleApiService = GlobalContext.getHandleApiService();
+    private final ProtocolHandlerRegistry handlerRegistry;
     private final Logger logger;
 
     public HandleProtocolMessage(Logger logger, Gson gson) {
         this.logger = logger;
         this.gson = gson;
+        this.handlerRegistry = createDefaultHandlerRegistry(gson, logger, GlobalContext.getHandleApiService());
+    }
+
+    public HandleProtocolMessage(Logger logger, Gson gson, ProtocolHandlerRegistry handlerRegistry) {
+        this.logger = logger;
+        this.gson = gson;
+        this.handlerRegistry = handlerRegistry;
+    }
+
+    private static ProtocolHandlerRegistry createDefaultHandlerRegistry(Gson gson, Logger logger, HandleApiService handleApiService) {
+        return new ProtocolHandlerRegistry()
+                .register("broadcast", new BroadcastHandler(gson, handleApiService))
+                .register("send_msg", new BroadcastHandler(gson, handleApiService))
+                .register("send_title", new SendTitleHandler(gson, handleApiService))
+                .register("send_actionbar", new SendActionBarHandler(gson, handleApiService))
+                .register("send_private_msg", new SendPrivateMessageHandler(gson, handleApiService))
+                .register("send_command", new SendCommandHandler())
+                .register("send_rcon_command", new SendRconCommandHandler(gson, logger))
+                .register("get_status", new GetStatusHandler(logger));
     }
 
     /**
@@ -88,60 +113,11 @@ public class HandleProtocolMessage {
      */
     public Response parseAndHandle(BasePayload basePayload) {
         String api = basePayload.getApi();
-        JsonElement data = basePayload.getData();
-
-        switch (basePayload.getApi()) {
-            case "broadcast":
-            case "send_msg": {
-                MessagePayload messagePayload = gson.fromJson(data, MessagePayload.class);
-                handleApiService.handleBroadcastMessage(messagePayload.getMessage());
-                return Response.success();
-            }
-            case "send_title": {
-                TitlePayload titlePayload = gson.fromJson(data, TitlePayload.class);
-                if ((titlePayload.getTitle() == null || titlePayload.getTitle().isJsonNull()) && (titlePayload.getSubtitle() == null || titlePayload.getSubtitle().isJsonNull())) {
-                    return Response.failed(400, "Title and Subtitle cannot both be null");
-                }
-                handleApiService.handleSendTitleMessage(titlePayload.getTitle(), titlePayload.getSubtitle(), titlePayload.getFadeIn(), titlePayload.getStay(), titlePayload.getFadeOut());
-                return Response.success();
-            }
-            case "send_actionbar": {
-                MessagePayload actionMessagePayload = gson.fromJson(data, MessagePayload.class);
-                handleApiService.handleSendActionBarMessage(actionMessagePayload.getMessage());
-                return Response.success();
-            }
-            case "send_private_msg": {
-                PrivateMessagePayload privateMessagePayload = gson.fromJson(data, PrivateMessagePayload.class);
-                if ((privateMessagePayload.getNickname() == null || privateMessagePayload.getNickname().isEmpty()) && privateMessagePayload.getUuid() == null) {
-                    return Response.failed(400, PrivateMessageResponse.playerIsNull().getMessage(), PrivateMessageResponse.playerIsNull());
-                }
-                PrivateMessageResponse privateMessageResponse = handleApiService.handleSendPrivateMessage(privateMessagePayload.getNickname(), privateMessagePayload.getUuid(), privateMessagePayload.getMessage());
-                return Response.success(privateMessageResponse);
-            }
-            case "send_command":
-                return Response.failed(500, api + " is not supported now");
-            case "send_rcon_command":
-                CommandPayload commandPayload = gson.fromJson(data, CommandPayload.class);
-                String result;
-                try {
-                    result = GlobalContext.sendRconCommand(commandPayload.getCommand());
-                    logger.info("发送 Rcon 命令: {}", commandPayload.getCommand());
-                    return Response.success(result);
-                } catch (Exception e) {
-                    String errorMessage = e.getMessage() != null ? e.getMessage() : "failed";
-                    logger.warn("Rcon 执行命令时出现问题，命令发送失败！{}", errorMessage);
-                    HashMap<Object, Object> resultData = new HashMap<>();
-                    resultData.put("command", commandPayload.getCommand());
-                    resultData.put("error", errorMessage);
-                    return Response.failed(400, errorMessage, resultData);
-                }
-            case "get_status": {
-                logger.info("收到 get_status 请求，已返回服务器状态");
-                return Response.success(ServerStatusCollector.collectStatusSnapshot());
-            }
-            default:
-                this.logger.warn(BaseConstant.UNKNOWN_API + "{}", api);
-                return Response.failed(404, BaseConstant.UNKNOWN_API + api);
+        ProtocolHandler handler = handlerRegistry.get(api);
+        if (handler == null) {
+            this.logger.warn(BaseConstant.UNKNOWN_API + "{}", api);
+            return Response.failed(404, BaseConstant.UNKNOWN_API + api);
         }
+        return handler.handle(basePayload);
     }
 }

--- a/src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/HandleProtocolMessage.java
@@ -3,7 +3,7 @@ package com.github.theword.queqiao.tool.handle;
 import static com.github.theword.queqiao.tool.utils.Tool.debugLog;
 
 import com.github.theword.queqiao.tool.GlobalContext;
-import com.github.theword.queqiao.tool.constant.BaseConstant;
+import com.github.theword.queqiao.tool.constant.ApiConstants;
 import com.github.theword.queqiao.tool.handle.protocol.BroadcastHandler;
 import com.github.theword.queqiao.tool.handle.protocol.GetStatusHandler;
 import com.github.theword.queqiao.tool.handle.protocol.ProtocolHandler;
@@ -44,14 +44,14 @@ public class HandleProtocolMessage {
 
     private static ProtocolHandlerRegistry createDefaultHandlerRegistry(Gson gson, Logger logger, HandleApiService handleApiService) {
         return new ProtocolHandlerRegistry()
-                .register("broadcast", new BroadcastHandler(gson, handleApiService))
-                .register("send_msg", new BroadcastHandler(gson, handleApiService))
-                .register("send_title", new SendTitleHandler(gson, handleApiService))
-                .register("send_actionbar", new SendActionBarHandler(gson, handleApiService))
-                .register("send_private_msg", new SendPrivateMessageHandler(gson, handleApiService))
-                .register("send_command", new SendCommandHandler())
-                .register("send_rcon_command", new SendRconCommandHandler(gson, logger))
-                .register("get_status", new GetStatusHandler(logger));
+                .register(ApiConstants.Api.BROADCAST, new BroadcastHandler(gson, handleApiService))
+                .register(ApiConstants.Api.SEND_MSG, new BroadcastHandler(gson, handleApiService))
+                .register(ApiConstants.Api.SEND_TITLE, new SendTitleHandler(gson, handleApiService))
+                .register(ApiConstants.Api.SEND_ACTIONBAR, new SendActionBarHandler(gson, handleApiService))
+                .register(ApiConstants.Api.SEND_PRIVATE_MSG, new SendPrivateMessageHandler(gson, handleApiService))
+                .register(ApiConstants.Api.SEND_COMMAND, new SendCommandHandler())
+                .register(ApiConstants.Api.SEND_RCON_COMMAND, new SendRconCommandHandler(gson, logger))
+                .register(ApiConstants.Api.GET_STATUS, new GetStatusHandler(logger));
     }
 
     /**
@@ -102,7 +102,7 @@ public class HandleProtocolMessage {
             this.logger.error("错误信息：", e);
             HashMap<String, String> data = new HashMap<>();
             data.put("rawJsonMessage", rawJsonMessage);
-            return Response.failed(500, "解析消息失败", data, null);
+            return Response.failed(ApiConstants.Code.INTERNAL_ERROR, ApiConstants.Message.PARSE_MESSAGE_FAILED, data, null);
         }
     }
 
@@ -115,8 +115,8 @@ public class HandleProtocolMessage {
         String api = basePayload.getApi();
         ProtocolHandler handler = handlerRegistry.get(api);
         if (handler == null) {
-            this.logger.warn(BaseConstant.UNKNOWN_API + "{}", api);
-            return Response.failed(404, BaseConstant.UNKNOWN_API + api);
+            this.logger.warn(ApiConstants.Message.UNKNOWN_API + "{}", api);
+            return Response.failed(ApiConstants.Code.NOT_FOUND, ApiConstants.Message.UNKNOWN_API + api);
         }
         return handler.handle(basePayload);
     }

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/BroadcastHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/BroadcastHandler.java
@@ -1,0 +1,27 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.handle.HandleApiService;
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.payload.MessagePayload;
+import com.github.theword.queqiao.tool.response.Response;
+import com.google.gson.Gson;
+
+/**
+ * 处理广播消息 API。
+ */
+public class BroadcastHandler implements ProtocolHandler {
+    private final Gson gson;
+    private final HandleApiService handleApiService;
+
+    public BroadcastHandler(Gson gson, HandleApiService handleApiService) {
+        this.gson = gson;
+        this.handleApiService = handleApiService;
+    }
+
+    @Override
+    public Response handle(BasePayload payload) {
+        MessagePayload messagePayload = gson.fromJson(payload.getData(), MessagePayload.class);
+        handleApiService.handleBroadcastMessage(messagePayload.getMessage());
+        return Response.success();
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/GetStatusHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/GetStatusHandler.java
@@ -1,0 +1,23 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.response.Response;
+import com.github.theword.queqiao.tool.utils.ServerStatusCollector;
+import org.slf4j.Logger;
+
+/**
+ * 处理服务器状态查询 API。
+ */
+public class GetStatusHandler implements ProtocolHandler {
+    private final Logger logger;
+
+    public GetStatusHandler(Logger logger) {
+        this.logger = logger;
+    }
+
+    @Override
+    public Response handle(BasePayload payload) {
+        logger.info("收到 get_status 请求，已返回服务器状态");
+        return Response.success(ServerStatusCollector.collectStatusSnapshot());
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/ProtocolHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/ProtocolHandler.java
@@ -1,0 +1,17 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.response.Response;
+
+/**
+ * 单个协议 API 的处理器。
+ */
+public interface ProtocolHandler {
+    /**
+     * 处理协议请求。
+     *
+     * @param payload 基础请求负载
+     * @return 响应
+     */
+    Response handle(BasePayload payload);
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/ProtocolHandlerRegistry.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/ProtocolHandlerRegistry.java
@@ -1,0 +1,20 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 协议 API 处理器注册表。
+ */
+public class ProtocolHandlerRegistry {
+    private final Map<String, ProtocolHandler> handlers = new HashMap<>();
+
+    public ProtocolHandlerRegistry register(String api, ProtocolHandler handler) {
+        handlers.put(api, handler);
+        return this;
+    }
+
+    public ProtocolHandler get(String api) {
+        return handlers.get(api);
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/ProtocolHandlerRegistry.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/ProtocolHandlerRegistry.java
@@ -1,5 +1,7 @@
 package com.github.theword.queqiao.tool.handle.protocol;
 
+import com.github.theword.queqiao.tool.exception.protocol.ProtocolHandlerRegistryException;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,6 +12,15 @@ public class ProtocolHandlerRegistry {
     private final Map<String, ProtocolHandler> handlers = new HashMap<>();
 
     public ProtocolHandlerRegistry register(String api, ProtocolHandler handler) {
+        if (api == null || api.isEmpty()) {
+            throw ProtocolHandlerRegistryException.apiBlank();
+        }
+        if (handler == null) {
+            throw ProtocolHandlerRegistryException.handlerNull(api);
+        }
+        if (handlers.containsKey(api)) {
+            throw ProtocolHandlerRegistryException.duplicated(api);
+        }
         handlers.put(api, handler);
         return this;
     }

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendActionBarHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendActionBarHandler.java
@@ -1,0 +1,27 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.handle.HandleApiService;
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.payload.MessagePayload;
+import com.github.theword.queqiao.tool.response.Response;
+import com.google.gson.Gson;
+
+/**
+ * 处理 ActionBar 消息 API。
+ */
+public class SendActionBarHandler implements ProtocolHandler {
+    private final Gson gson;
+    private final HandleApiService handleApiService;
+
+    public SendActionBarHandler(Gson gson, HandleApiService handleApiService) {
+        this.gson = gson;
+        this.handleApiService = handleApiService;
+    }
+
+    @Override
+    public Response handle(BasePayload payload) {
+        MessagePayload actionMessagePayload = gson.fromJson(payload.getData(), MessagePayload.class);
+        handleApiService.handleSendActionBarMessage(actionMessagePayload.getMessage());
+        return Response.success();
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendCommandHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendCommandHandler.java
@@ -1,5 +1,6 @@
 package com.github.theword.queqiao.tool.handle.protocol;
 
+import com.github.theword.queqiao.tool.constant.ApiConstants;
 import com.github.theword.queqiao.tool.payload.BasePayload;
 import com.github.theword.queqiao.tool.response.Response;
 
@@ -9,6 +10,6 @@ import com.github.theword.queqiao.tool.response.Response;
 public class SendCommandHandler implements ProtocolHandler {
     @Override
     public Response handle(BasePayload payload) {
-        return Response.failed(500, payload.getApi() + " is not supported now");
+        return Response.failed(ApiConstants.Code.INTERNAL_ERROR, String.format(ApiConstants.Message.SEND_COMMAND_UNSUPPORTED, payload.getApi()));
     }
 }

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendCommandHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendCommandHandler.java
@@ -1,0 +1,14 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.response.Response;
+
+/**
+ * 处理命令发送 API。
+ */
+public class SendCommandHandler implements ProtocolHandler {
+    @Override
+    public Response handle(BasePayload payload) {
+        return Response.failed(500, payload.getApi() + " is not supported now");
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendPrivateMessageHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendPrivateMessageHandler.java
@@ -1,5 +1,6 @@
 package com.github.theword.queqiao.tool.handle.protocol;
 
+import com.github.theword.queqiao.tool.constant.ApiConstants;
 import com.github.theword.queqiao.tool.handle.HandleApiService;
 import com.github.theword.queqiao.tool.payload.BasePayload;
 import com.github.theword.queqiao.tool.payload.PrivateMessagePayload;
@@ -23,7 +24,7 @@ public class SendPrivateMessageHandler implements ProtocolHandler {
     public Response handle(BasePayload payload) {
         PrivateMessagePayload privateMessagePayload = gson.fromJson(payload.getData(), PrivateMessagePayload.class);
         if ((privateMessagePayload.getNickname() == null || privateMessagePayload.getNickname().isEmpty()) && privateMessagePayload.getUuid() == null) {
-            return Response.failed(400, PrivateMessageResponse.playerIsNull().getMessage(), PrivateMessageResponse.playerIsNull());
+            return Response.failed(ApiConstants.Code.BAD_REQUEST, PrivateMessageResponse.playerIsNull().getMessage(), PrivateMessageResponse.playerIsNull());
         }
         PrivateMessageResponse privateMessageResponse = handleApiService.handleSendPrivateMessage(privateMessagePayload.getNickname(), privateMessagePayload.getUuid(), privateMessagePayload.getMessage());
         return Response.success(privateMessageResponse);

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendPrivateMessageHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendPrivateMessageHandler.java
@@ -1,0 +1,31 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.handle.HandleApiService;
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.payload.PrivateMessagePayload;
+import com.github.theword.queqiao.tool.response.PrivateMessageResponse;
+import com.github.theword.queqiao.tool.response.Response;
+import com.google.gson.Gson;
+
+/**
+ * 处理私聊消息 API。
+ */
+public class SendPrivateMessageHandler implements ProtocolHandler {
+    private final Gson gson;
+    private final HandleApiService handleApiService;
+
+    public SendPrivateMessageHandler(Gson gson, HandleApiService handleApiService) {
+        this.gson = gson;
+        this.handleApiService = handleApiService;
+    }
+
+    @Override
+    public Response handle(BasePayload payload) {
+        PrivateMessagePayload privateMessagePayload = gson.fromJson(payload.getData(), PrivateMessagePayload.class);
+        if ((privateMessagePayload.getNickname() == null || privateMessagePayload.getNickname().isEmpty()) && privateMessagePayload.getUuid() == null) {
+            return Response.failed(400, PrivateMessageResponse.playerIsNull().getMessage(), PrivateMessageResponse.playerIsNull());
+        }
+        PrivateMessageResponse privateMessageResponse = handleApiService.handleSendPrivateMessage(privateMessagePayload.getNickname(), privateMessagePayload.getUuid(), privateMessagePayload.getMessage());
+        return Response.success(privateMessageResponse);
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendRconCommandHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendRconCommandHandler.java
@@ -1,0 +1,41 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.GlobalContext;
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.payload.CommandPayload;
+import com.github.theword.queqiao.tool.response.Response;
+import com.google.gson.Gson;
+import org.slf4j.Logger;
+
+import java.util.HashMap;
+
+/**
+ * 处理 Rcon 命令 API。
+ */
+public class SendRconCommandHandler implements ProtocolHandler {
+    private final Gson gson;
+    private final Logger logger;
+
+    public SendRconCommandHandler(Gson gson, Logger logger) {
+        this.gson = gson;
+        this.logger = logger;
+    }
+
+    @Override
+    public Response handle(BasePayload payload) {
+        CommandPayload commandPayload = gson.fromJson(payload.getData(), CommandPayload.class);
+        String result;
+        try {
+            result = GlobalContext.sendRconCommand(commandPayload.getCommand());
+            logger.info("发送 Rcon 命令: {}", commandPayload.getCommand());
+            return Response.success(result);
+        } catch (Exception e) {
+            String errorMessage = e.getMessage() != null ? e.getMessage() : "failed";
+            logger.warn("Rcon 执行命令时出现问题，命令发送失败！{}", errorMessage);
+            HashMap<Object, Object> resultData = new HashMap<>();
+            resultData.put("command", commandPayload.getCommand());
+            resultData.put("error", errorMessage);
+            return Response.failed(400, errorMessage, resultData);
+        }
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendRconCommandHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendRconCommandHandler.java
@@ -1,6 +1,8 @@
 package com.github.theword.queqiao.tool.handle.protocol;
 
 import com.github.theword.queqiao.tool.GlobalContext;
+import com.github.theword.queqiao.tool.constant.ApiConstants;
+import com.github.theword.queqiao.tool.exception.rcon.RconCommandException;
 import com.github.theword.queqiao.tool.payload.BasePayload;
 import com.github.theword.queqiao.tool.payload.CommandPayload;
 import com.github.theword.queqiao.tool.response.Response;
@@ -29,13 +31,30 @@ public class SendRconCommandHandler implements ProtocolHandler {
             result = GlobalContext.sendRconCommand(commandPayload.getCommand());
             logger.info("发送 Rcon 命令: {}", commandPayload.getCommand());
             return Response.success(result);
-        } catch (Exception e) {
-            String errorMessage = e.getMessage() != null ? e.getMessage() : "failed";
-            logger.warn("Rcon 执行命令时出现问题，命令发送失败！{}", errorMessage);
-            HashMap<Object, Object> resultData = new HashMap<>();
-            resultData.put("command", commandPayload.getCommand());
-            resultData.put("error", errorMessage);
-            return Response.failed(400, errorMessage, resultData);
+        } catch (RconCommandException e) {
+            return handleRconCommandException(commandPayload.getCommand(), e);
         }
+    }
+
+    private Response handleRconCommandException(String command, RconCommandException e) {
+        switch (e.getReason()) {
+            case DISABLED:
+                logger.warn("Rcon 命令发送失败，Rcon 未启用。command={}", command);
+                return failed(command, ApiConstants.Code.BAD_REQUEST, e.getMessage());
+            case NOT_CONNECTED:
+                logger.warn("Rcon 命令发送失败，Rcon 未连接。command={}", command);
+                return failed(command, ApiConstants.Code.BAD_REQUEST, e.getMessage());
+            case FAILED:
+            default:
+                logger.warn("Rcon 执行命令时出现问题，命令发送失败！command={}, error={}", command, e.getMessage(), e);
+                return failed(command, ApiConstants.Code.INTERNAL_ERROR, e.getMessage());
+        }
+    }
+
+    private Response failed(String command, int code, String errorMessage) {
+        HashMap<Object, Object> resultData = new HashMap<>();
+        resultData.put("command", command);
+        resultData.put("error", errorMessage);
+        return Response.failed(code, errorMessage, resultData);
     }
 }

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendTitleHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendTitleHandler.java
@@ -1,5 +1,6 @@
 package com.github.theword.queqiao.tool.handle.protocol;
 
+import com.github.theword.queqiao.tool.constant.ApiConstants;
 import com.github.theword.queqiao.tool.handle.HandleApiService;
 import com.github.theword.queqiao.tool.payload.BasePayload;
 import com.github.theword.queqiao.tool.payload.TitlePayload;
@@ -22,7 +23,7 @@ public class SendTitleHandler implements ProtocolHandler {
     public Response handle(BasePayload payload) {
         TitlePayload titlePayload = gson.fromJson(payload.getData(), TitlePayload.class);
         if ((titlePayload.getTitle() == null || titlePayload.getTitle().isJsonNull()) && (titlePayload.getSubtitle() == null || titlePayload.getSubtitle().isJsonNull())) {
-            return Response.failed(400, "Title and Subtitle cannot both be null");
+            return Response.failed(ApiConstants.Code.BAD_REQUEST, ApiConstants.Message.TITLE_AND_SUBTITLE_EMPTY);
         }
         handleApiService.handleSendTitleMessage(titlePayload.getTitle(), titlePayload.getSubtitle(), titlePayload.getFadeIn(), titlePayload.getStay(), titlePayload.getFadeOut());
         return Response.success();

--- a/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendTitleHandler.java
+++ b/src/main/java/com/github/theword/queqiao/tool/handle/protocol/SendTitleHandler.java
@@ -1,0 +1,30 @@
+package com.github.theword.queqiao.tool.handle.protocol;
+
+import com.github.theword.queqiao.tool.handle.HandleApiService;
+import com.github.theword.queqiao.tool.payload.BasePayload;
+import com.github.theword.queqiao.tool.payload.TitlePayload;
+import com.github.theword.queqiao.tool.response.Response;
+import com.google.gson.Gson;
+
+/**
+ * 处理标题消息 API。
+ */
+public class SendTitleHandler implements ProtocolHandler {
+    private final Gson gson;
+    private final HandleApiService handleApiService;
+
+    public SendTitleHandler(Gson gson, HandleApiService handleApiService) {
+        this.gson = gson;
+        this.handleApiService = handleApiService;
+    }
+
+    @Override
+    public Response handle(BasePayload payload) {
+        TitlePayload titlePayload = gson.fromJson(payload.getData(), TitlePayload.class);
+        if ((titlePayload.getTitle() == null || titlePayload.getTitle().isJsonNull()) && (titlePayload.getSubtitle() == null || titlePayload.getSubtitle().isJsonNull())) {
+            return Response.failed(400, "Title and Subtitle cannot both be null");
+        }
+        handleApiService.handleSendTitleMessage(titlePayload.getTitle(), titlePayload.getSubtitle(), titlePayload.getFadeIn(), titlePayload.getStay(), titlePayload.getFadeOut());
+        return Response.success();
+    }
+}

--- a/src/main/java/com/github/theword/queqiao/tool/payload/PrivateMessagePayload.java
+++ b/src/main/java/com/github/theword/queqiao/tool/payload/PrivateMessagePayload.java
@@ -1,7 +1,6 @@
 package com.github.theword.queqiao.tool.payload;
 
 import com.google.gson.JsonElement;
-import com.google.gson.annotations.SerializedName;
 
 import java.util.UUID;
 

--- a/src/main/java/com/github/theword/queqiao/tool/rcon/RconClient.java
+++ b/src/main/java/com/github/theword/queqiao/tool/rcon/RconClient.java
@@ -1,5 +1,6 @@
 package com.github.theword.queqiao.tool.rcon;
 
+import com.github.theword.queqiao.tool.exception.rcon.RconCommandException;
 import org.glavo.rcon.AuthenticationException;
 import org.glavo.rcon.Rcon;
 import org.slf4j.Logger;
@@ -37,11 +38,15 @@ public class RconClient {
         }
     }
 
-    public String sendCommand(String command) throws IOException {
+    public String sendCommand(String command) throws RconCommandException {
         if (!isConnected()) {
-            throw new IllegalArgumentException("Rcon 未连接");
+            throw RconCommandException.notConnected();
         }
-        return client.command(command);
+        try {
+            return client.command(command);
+        } catch (IOException e) {
+            throw RconCommandException.failed(e);
+        }
     }
 
     /**

--- a/src/main/java/com/github/theword/queqiao/tool/response/ResponseEnum.java
+++ b/src/main/java/com/github/theword/queqiao/tool/response/ResponseEnum.java
@@ -1,5 +1,7 @@
 package com.github.theword.queqiao.tool.response;
 
+import com.github.theword.queqiao.tool.exception.protocol.ResponseStatusException;
+
 public enum ResponseEnum {
     SUCCESS("SUCCESS"), FAILED("FAILED");
 
@@ -24,6 +26,6 @@ public enum ResponseEnum {
                 return response;
             }
         }
-        throw new IllegalArgumentException("Unknown value: " + value);
+        throw ResponseStatusException.unknown(value);
     }
 }

--- a/src/main/java/com/github/theword/queqiao/tool/utils/MinecraftPingClient.java
+++ b/src/main/java/com/github/theword/queqiao/tool/utils/MinecraftPingClient.java
@@ -1,10 +1,10 @@
 package com.github.theword.queqiao.tool.utils;
 
 import com.github.theword.queqiao.tool.GlobalContext;
+import com.github.theword.queqiao.tool.exception.status.MinecraftPingException;
 import com.google.gson.reflect.TypeToken;
 
 import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -20,7 +20,7 @@ final class MinecraftPingClient {
     private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {
     }.getType();
 
-    Map<String, Object> fetchStatus(String host, int port) throws IOException {
+    Map<String, Object> fetchStatus(String host, int port) throws MinecraftPingException {
         try (Socket socket = new Socket()) {
             socket.connect(new InetSocketAddress(host, port), SOCKET_TIMEOUT_MILLIS);
             socket.setSoTimeout(SOCKET_TIMEOUT_MILLIS);
@@ -33,26 +33,30 @@ final class MinecraftPingClient {
 
             int responsePacketLength = readVarInt(inputStream);
             if (responsePacketLength <= 0) {
-                throw new IOException("状态响应包长度非法: " + responsePacketLength);
+                throw MinecraftPingException.invalidPacketLength(responsePacketLength);
             }
 
             int packetId = readVarInt(inputStream);
             if (packetId != 0x00) {
-                throw new IOException("状态响应包 ID 非法: " + packetId);
+                throw MinecraftPingException.invalidPacketId(packetId);
             }
 
             int jsonLength = readVarInt(inputStream);
             if (jsonLength <= 0) {
-                throw new IOException("状态响应 JSON 长度非法: " + jsonLength);
+                throw MinecraftPingException.invalidJsonLength(jsonLength);
             }
 
             byte[] jsonBytes = readFully(inputStream, jsonLength);
             String json = new String(jsonBytes, StandardCharsets.UTF_8);
             Map<String, Object> pingData = GlobalContext.getGson().fromJson(json, MAP_TYPE);
             if (pingData == null) {
-                throw new IOException("状态响应 JSON 解析失败");
+                throw MinecraftPingException.jsonParseFailed();
             }
             return pingData;
+        } catch (MinecraftPingException e) {
+            throw e;
+        } catch (IOException e) {
+            throw MinecraftPingException.ioFailed(e);
         }
     }
 
@@ -103,32 +107,32 @@ final class MinecraftPingClient {
         }
     }
 
-    private int readVarInt(InputStream inputStream) throws IOException {
+    private int readVarInt(InputStream inputStream) throws IOException, MinecraftPingException {
         int numRead = 0;
         int result = 0;
         int read;
         do {
             read = inputStream.read();
             if (read == -1) {
-                throw new EOFException("读取 VarInt 时连接提前关闭");
+                throw MinecraftPingException.connectionClosed("读取 VarInt 时连接提前关闭");
             }
             int value = read & 0x7F;
             result |= value << (7 * numRead);
             numRead++;
             if (numRead > 5) {
-                throw new IOException("VarInt 过长");
+                throw MinecraftPingException.varIntTooLong();
             }
         } while ((read & 0x80) != 0);
         return result;
     }
 
-    private byte[] readFully(InputStream inputStream, int length) throws IOException {
+    private byte[] readFully(InputStream inputStream, int length) throws IOException, MinecraftPingException {
         byte[] data = new byte[length];
         int offset = 0;
         while (offset < length) {
             int readCount = inputStream.read(data, offset, length - offset);
             if (readCount == -1) {
-                throw new EOFException("读取状态响应时连接提前关闭");
+                throw MinecraftPingException.connectionClosed("读取状态响应时连接提前关闭");
             }
             offset += readCount;
         }

--- a/src/main/java/com/github/theword/queqiao/tool/utils/ServerStatusCollector.java
+++ b/src/main/java/com/github/theword/queqiao/tool/utils/ServerStatusCollector.java
@@ -2,6 +2,7 @@ package com.github.theword.queqiao.tool.utils;
 
 import com.github.theword.queqiao.tool.GlobalContext;
 import com.github.theword.queqiao.tool.constant.BaseConstant;
+import com.github.theword.queqiao.tool.exception.status.MinecraftPingException;
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.Yaml;
 
@@ -299,6 +300,13 @@ public final class ServerStatusCollector {
     }
 
     private static String resolvePingFailureReason(Exception exception) {
+        if (exception instanceof MinecraftPingException) {
+            MinecraftPingException pingException = (MinecraftPingException) exception;
+            if (pingException.getReason() == MinecraftPingException.Reason.IO_FAILED && pingException.getCause() instanceof Exception) {
+                return resolvePingFailureReason((Exception) pingException.getCause());
+            }
+            return "invalid_response";
+        }
         if (exception instanceof SocketTimeoutException) {
             return "timeout";
         }

--- a/src/main/java/com/github/theword/queqiao/tool/utils/WebsocketManager.java
+++ b/src/main/java/com/github/theword/queqiao/tool/utils/WebsocketManager.java
@@ -129,6 +129,7 @@ public class WebsocketManager {
                 wsServer.stop(0, reason);
                 this.handleCommandReturnMessageService.sendReturnMessage(commandReturner, reason);
             } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 this.handleCommandReturnMessageService.sendReturnMessage(commandReturner, WebsocketConstantMessage.Server.ERROR_ON_STOPPING);
                 Tool.debugLog(e.getMessage());
             }

--- a/src/test/java/com/github/theword/queqiao/tool/response/ResponseEnumTest.java
+++ b/src/test/java/com/github/theword/queqiao/tool/response/ResponseEnumTest.java
@@ -1,5 +1,6 @@
 package com.github.theword.queqiao.tool.response;
 
+import com.github.theword.queqiao.tool.exception.protocol.ResponseStatusException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,10 +13,10 @@ class ResponseEnumTest {
         assertEquals(ResponseEnum.FAILED, ResponseEnum.fromString("FAILED"));
         assertEquals(ResponseEnum.SUCCESS, ResponseEnum.fromString("success"));
         assertEquals(ResponseEnum.FAILED, ResponseEnum.fromString("failed"));
-        Exception exception = assertThrows(IllegalArgumentException.class, () -> {
+        Exception exception = assertThrows(ResponseStatusException.class, () -> {
             ResponseEnum.fromString("UNKNOWN");
         });
-        assertEquals("Unknown value: UNKNOWN", exception.getMessage());
+        assertEquals("Unknown response status: UNKNOWN", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## Summary by Sourcery

重构协议消息处理机制，使用可插拔的处理器注册表，并为 QueQiaoTool 模块新增项目级文档。

增强功能：
- 将 `HandleProtocolMessage` 中基于大规模 `switch` 的单体式 API 分发逻辑，替换为 `ProtocolHandlerRegistry` 和可注入的协议处理器，以提高可扩展性和可测试性。
- 为广播、动作栏、标题、私聊、Rcon 命令、状态查询以及不支持的命令等 API 引入专门的处理器类。

文档：
- 新增一份详细的 Markdown 项目概览文档，说明 QueQiaoTool 的架构、功能、配置方式以及维护注意事项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor protocol message handling to use a pluggable handler registry and add project-level documentation for the QueQiaoTool module.

Enhancements:
- Replace the monolithic switch-based API dispatch in HandleProtocolMessage with a ProtocolHandlerRegistry and injectable protocol handlers for better extensibility and testability.
- Introduce dedicated handler classes for broadcast, action bar, title, private message, Rcon command, status query, and unsupported command APIs.

Documentation:
- Add a detailed markdown project summary describing QueQiaoTool’s architecture, capabilities, configuration, and maintenance considerations.

</details>